### PR TITLE
Round Fortnite stats to nearest integer except KD

### DIFF
--- a/commands/fortnite.js
+++ b/commands/fortnite.js
@@ -50,9 +50,9 @@ function formatInfo(data, mode) {
 	return `Matches: ${data.stats[mode].matches}
 Kills: ${data.stats[mode].kills}
 Score: ${data.stats[mode].score}
-Score/Kills: ${data.stats[mode].score/data.stats[mode].kills}
-Score/Match: ${data.stats[mode].score_per_match}
-Score/Kills Per Match: ${data.stats[mode].score_per_match/data.stats[mode].kills}
+Score/Kills: ${Math.round(data.stats[mode].score/data.stats[mode].kills)}
+Score/Match: ${Math.round(data.stats[mode].score_per_match)}
+Score/Kills Per Match: ${Math.round(data.stats[mode].score_per_match/data.stats[mode].kills)}
 K/D: ${data.stats[mode].kd}
 Wins: ${data.stats[mode].wins}
 Top 3s: ${data.stats[mode].top_3}


### PR DESCRIPTION
I rounded the stats to nearest integer as you asked in #91. As for what you said about the stats not being shown correctly, I compared your picture with https://fortnitetracker.com/profile/pc/shadowolfyt and the bot's output looked right to me.